### PR TITLE
Update debian base image to bookworm

### DIFF
--- a/aiohttp-app/Dockerfile
+++ b/aiohttp-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 RUN pip install poetry==1.2.2
 

--- a/fastapi-app/Dockerfile
+++ b/fastapi-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 RUN pip install poetry==2.0.1
 


### PR DESCRIPTION
Both the aiohttp-app and fastapi-app Dockerfiles are using python:3.11-slim-buster as the base image. Debian Buster is end-of-life and its repositories have been archived. I've updated the base images to bookwork so that the Docker image can be built.